### PR TITLE
Add support for custom suffix formats using %N% in namecrement

### DIFF
--- a/.idea/dictionaries/project.xml
+++ b/.idea/dictionaries/project.xml
@@ -1,6 +1,7 @@
 <component name="ProjectDictionaryState">
   <dictionary name="project">
     <words>
+      <w>filex</w>
       <w>namecrement</w>
     </words>
   </dictionary>

--- a/README.md
+++ b/README.md
@@ -48,6 +48,32 @@ $newName = Namecrement::namecrement('file', $existing);
 echo $newName; 
 // Outputs: "file (3)"
 ```
+---
+
+## 🧠 Advanced Usage
+
+You can customize the suffix format using the `%N%` placeholder to define how the number is added:
+
+```php
+Namecrement::namecrement('file', ['file', 'file -1-', 'file -2-'], ' -%N%-');
+// ➔ 'file -3-'
+
+Namecrement::namecrement('version', ['version', 'version<v1>'], '<v%N%>');
+// ➔ 'version<v2>'
+```
+
+### 🛡 Suffix Format Rules
+
+- The `suffixFormat` **must include** `%N%`, or an `InvalidArgumentException` will be thrown.
+- `%N%` will be replaced by the next available number.
+- Default format is `" (%N%)"`.
+
+| Format Example    | Result              |
+|-------------------|---------------------|
+| `" (%N%)"`        | `file (1)`          |
+| `-%N%`            | `file-1`            |
+| `_<v%N%>`         | `file_<v1>`         |
+| `_%N%_`           | `file_1_`           |
 
 ---
 
@@ -55,10 +81,11 @@ echo $newName;
 
 ### `namecrement(string $baseName, array $existingNames): string`
 
-| Parameter       | Type     | Description                    |
-|-----------------|----------|--------------------------------|
-| `baseName`      | string   | Proposed name to start from    |
-| `existingNames` | string[] | List of already existing names |
+| Parameter       | Type     | Description                           |
+|-----------------|----------|---------------------------------------|
+| `baseName`      | string   | Proposed name to start from           |
+| `existingNames` | string[] | List of already existing names        |
+| `suffixFormat`  | string   | Optional format for suffix (optional) |
 
 Returns the next available **unique name**.
 
@@ -67,14 +94,16 @@ Returns the next available **unique name**.
 ## 🛠 Examples
 
 ```php
-namecrement('report', ['report', 'report (1)']);
+Namecrement::namecrement('report', ['report', 'report (1)']);
 // ➔ 'report (2)'
 
-namecrement('image', ['photo', 'image', 'image (1)', 'image (2)']);
+Namecrement::namecrement('image', ['photo', 'image', 'image (1)', 'image (2)']);
 // ➔ 'image (3)'
 
-namecrement('new', []);
+Namecrement::namecrement('new', []);
 // ➔ 'new'
+Namecrement::namecrement('file', ['file', 'file (1)', 'file (2)'], ' -%N%-');
+// ➔ 'file -1-'
 ```
 
 ---


### PR DESCRIPTION
# Description
This PR enhances the `namecrement` method by adding support for custom suffix formats using the `%N%` placeholder.

##  Features
- `suffixFormat` parameter lets you customize how suffixes are formatted (e.g., ` -%N%-`, `<v%N%>`, `_v%N%`)
- Default remains `" (%N%)"`
- Runtime validation: throws `InvalidArgumentException` if `%N%` is missing
- Fully backward-compatible with previous usage

## Examples

```php
Namecrement::namecrement('file', ['file', 'file -1-', 'file -2-'], ' -%N%-');
// → 'file -3-'

Namecrement::namecrement('v', ['v', 'v<1>', 'v<2>'], '<%N%>');
// → 'v<3>'
```

## Tests
- Pest tests updated and extended
- Covers gaps, spacing, special characters, invalid formats, and advanced usage

## Docs
- README updated with examples and usage guidelines